### PR TITLE
differentiate between 10 characters in hex and 5 bytes for the advertisement

### DIFF
--- a/main.md
+++ b/main.md
@@ -206,7 +206,7 @@ PDU:
             Data: OVPSTADONENTRY_8520f00989 (3 character + 11 character identifier name + 10 character (5 bytes) of the random X25519 public key in hex repr. )
 ```
 
-The data in the Advertisement Packet contain the prefix `OVP` indicating that the verifier is ready to accept connections for OpenID 4 VPs. A human readable name of the verifier is given in the next part.  The rest of the data packet after the `_` contains the first 5 bytes of the public key in a hexadecimal representation (example: `8520f00989´). (max. available size for data as defined by BLE is 20 byte). 
+The data in the Advertisement Packet contain the prefix `OVP` indicating that the verifier is ready to accept connections for OpenID 4 VPs. A human readable name of the verifier is given in the next part.  The rest of the data packet after the `_` contains the first 5 bytes of the verifier public key in a hexadecimal representation (example: `8520f00989´). (max. available size for data as defined by BLE is 20 byte). 
 
 ### Scan Response Structure
 

--- a/main.md
+++ b/main.md
@@ -203,10 +203,10 @@ PDU:
         Adv Data: (17 byte)
             Adv Type: Complete Local Name
             flag: "LE General Discoverable Mode", "BR/EDR Not Supported"
-            Data: OVPSTADONENTRY_8520f00989 (3 character + 11 character identifier name + 5 bytes of the random X25519 public key)
+            Data: OVPSTADONENTRY_8520f00989 (3 character + 11 character identifier name + 10 character (5 bytes) of the random X25519 public key in hex repr. )
 ```
 
-The data in the Advertisement Packet contain the prefix `OVP` indicating that the verifier is ready to accept connections for OpenID 4 VPs. A human readable name of the verifier is given in the next part.  The rest of the data packet after the `_` contains the first 5 bytes of the public key (example: `8520f00989´). (max. available size for data as defined by BLE is 20 byte). 
+The data in the Advertisement Packet contain the prefix `OVP` indicating that the verifier is ready to accept connections for OpenID 4 VPs. A human readable name of the verifier is given in the next part.  The rest of the data packet after the `_` contains the first 5 bytes of the public key in a hexadecimal representation (example: `8520f00989´). (max. available size for data as defined by BLE is 20 byte). 
 
 ### Scan Response Structure
 


### PR DESCRIPTION
Added some clarification regarding the 10 characters (= 5 bytes in hex) representation of the public key bytes in the advertisement and that we talk about the verifier key.

I am still not 100% happy with it, I think line 206 should be much shorter. 
Maybe "... + 10 character of the public key" and the explanation below would be enough?